### PR TITLE
Modified regex to accomodate parameters in the URL

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Bandcamp Scrobbler",
-  "version": "1.4",
+  "version": "1.5",
   "description": "Scrobble albums on Bandcamp to Last.fm",
   "icons": {
     "16": "resource/icon16.png",

--- a/src/util/chrome.js
+++ b/src/util/chrome.js
@@ -1,6 +1,6 @@
 const { selectors } = require('./bandcamp');
 
-const albumRegex = /^https:\/\/[a-zA-Z0-9_-]+\.bandcamp\.com\/album\/[a-zA-Z0-9_-]+$/;
+const albumRegex = /^https:\/\/[a-zA-Z0-9_-]+\.bandcamp\.com\/album\/[a-zA-Z0-9_-]+[a-zA-Z0-9_=&+-?]*$/;
 const getHtml = `(function() { return document.documentElement.outerHTML; })()`;
 
 const sendMessage = (type, data, done) => {


### PR DESCRIPTION
Extension would not recognise the album page as valid if there were parameters at the end of the URL. Tested on Windows 10 and Ubuntu with Chrome 111.0.5563.65 / 111.0.5563.64 respectively